### PR TITLE
define rodata after data

### DIFF
--- a/xtensa.in.x
+++ b/xtensa.in.x
@@ -20,14 +20,6 @@ SECTIONS {
     _etext = .;
   } > ROTEXT
 
-  .rodata :
-  {
-    _rodata_start = ABSOLUTE(.);
-    . = ALIGN (4);
-    *(.rodata .rodata.*)
-    _rodata_end = ABSOLUTE(.);
-  } > RODATA
-
   .data :
   {
     _data_start = ABSOLUTE(.);
@@ -49,6 +41,14 @@ SECTIONS {
     . = ALIGN(4);
     *(.noinit .noinit.*)
   } > RWDATA
+
+  .rodata :
+  {
+    _rodata_start = ABSOLUTE(.);
+    . = ALIGN (4);
+    *(.rodata .rodata.*)
+    _rodata_end = ABSOLUTE(.);
+  } > RODATA
 
   .rwtext :
   {


### PR DESCRIPTION
this seems needed for esp8266 to get things to work properly (when placing rodata in ram at least)

I have no idea why this makes a difference though