### PR TITLE
Reset memory customization

### DIFF
--- a/xtensa.in.x
+++ b/xtensa.in.x
@@ -6,6 +6,8 @@ INCLUDE memory.x
 
 /* after memory.x to allow override */
 PROVIDE(__pre_init = DefaultPreInit);
+PROVIDE(__zero_bss = default_mem_hook);
+PROVIDE(__init_data = default_mem_hook);
 
 INCLUDE exception.x
 
@@ -36,6 +38,9 @@ SECTIONS {
     *(.data .data.*)
     _data_end = ABSOLUTE(.);
   } > RWDATA AT > RODATA
+
+  /* LMA of .data */
+  _sidata = LOADADDR(.data);
 
   .bss (NOLOAD) : ALIGN(4)
   {


### PR DESCRIPTION
* ability to choose where bss is zeroed and data is initialized.
  * the esp32 has a first stage bootloader that will do the data
  initialization for us, hence we don't need to do it here.
* defaults to true for both via `default_mem_hook`