### PR TITLE
Unify & feature gate Xtensa asm

### DIFF
--- a/src/exception.rs
+++ b/src/exception.rs
@@ -25,11 +25,11 @@
 #[cfg(feature = "lx106")]
 mod assembly_lx106;
 #[cfg(feature = "lx6")]
-mod assembly_lx6;
+mod assembly;
 #[cfg(feature = "lx106")]
 mod lx106;
 #[cfg(feature = "lx6")]
-mod lx6;
+mod lxx;
 
 /// EXCCAUSE register values
 ///
@@ -127,4 +127,4 @@ pub enum ExceptionCause {
 #[cfg(feature = "lx106")]
 pub use lx106::Context;
 #[cfg(feature = "lx6")]
-pub use lx6::Context;
+pub use lxx::Context;

--- a/src/exception/assembly.rs
+++ b/src/exception/assembly.rs
@@ -1,9 +1,10 @@
 use crate::cfg_asm;
 
-// TODO cfg symbols away and reduce BSA(base save area) depending on features enabled?
-// i.e the BSA is a fixed size based on all the features right now
+// TODO cfg symbols away and reduce frame size depending on features enabled?
+// i.e the frame size is a fixed size based on all the features right now
 // we know at compile time if a target has loops for example, if it doesn't
-// we can cut that memory usage from the BSA
+// we can cut that memory usage.
+// note that in esp-idf, it seems to be fixed at 256bytes for all chips?
 global_asm!(
     "
     .set XT_STK_PC,              0 
@@ -150,6 +151,9 @@ unsafe extern "C" fn save_context() {
         // Thread Pointer Option
         rur     a3, threadptr
         s32i    a3, sp, +XT_STK_THREADPTR
+        ",
+        #[cfg(target_feature = "s32c1i")]
+        "
         // Conditional Store Option
         rsr     a3, scompare1
         s32i    a3, sp, +XT_STK_SCOMPARE1
@@ -319,7 +323,7 @@ unsafe extern "C" fn restore_context() {
         l32i    a3, sp, +XT_STK_THREADPTR
         wur     a3, threadptr
         ",
-        #[cfg(target_feature = "threadptr")]
+        #[cfg(target_feature = "s32c1i")]
         "
         // Conditional Store Option
         l32i    a3, sp, +XT_STK_SCOMPARE1

--- a/src/exception/assembly.rs
+++ b/src/exception/assembly.rs
@@ -190,7 +190,7 @@ unsafe extern "C" fn save_context() {
         rur     a3, f64s   
         s32i    a3, sp, +XT_STK_F64S
         ",
-        #[cfg(target_feature = "coprocessor")]
+        #[cfg(target_feature = "fp")]
         "
         // Coprocessor Option
         rur     a3, fcr
@@ -361,7 +361,7 @@ unsafe extern "C" fn restore_context() {
         l32i    a3, sp, +XT_STK_F64S
         wur     a3, f64s
         ",
-        #[cfg(target_feature = "coprocessor")]
+        #[cfg(target_feature = "fp")]
         "
         // Coprocessor Option
         l32i    a3, sp, +XT_STK_FCR

--- a/src/exception/lxx.rs
+++ b/src/exception/lxx.rs
@@ -29,38 +29,78 @@ pub struct Context {
     SAR: u32,
     EXCCAUSE: u32,
     EXCVADDR: u32,
+
+    #[cfg(target_feature = "loop")]
     LBEG: u32,
+    #[cfg(target_feature = "loop")]
     LEND: u32,
+    #[cfg(target_feature = "loop")]
     LCOUNT: u32,
+
+    #[cfg(target_feature = "threadptr")]
     THREADPTR: u32,
+
+    #[cfg(target_feature = "s32c1i")]
     SCOMPARE1: u32,
+
+    #[cfg(target_feature = "bool")]
     BR: u32,
+
+    #[cfg(target_feature = "mac16")]
     ACCLO: u32,
+    #[cfg(target_feature = "mac16")]
     ACCHI: u32,
+    #[cfg(target_feature = "mac16")]
     M0: u32,
+    #[cfg(target_feature = "mac16")]
     M1: u32,
+    #[cfg(target_feature = "mac16")]
     M2: u32,
+    #[cfg(target_feature = "mac16")]
     M3: u32,
+
+    #[cfg(target_feature = "dfpaccel")]
     F64R_LO: u32,
+    #[cfg(target_feature = "dfpaccel")]
     F64R_HI: u32,
+    #[cfg(target_feature = "dfpaccel")]
     F64S: u32,
+
+    #[cfg(target_feature = "coprocessor")]
     FCR: u32,
+    #[cfg(target_feature = "coprocessor")]
     FSR: u32,
+    #[cfg(target_feature = "coprocessor")]
     F0: u32,
+    #[cfg(target_feature = "coprocessor")]
     F1: u32,
+    #[cfg(target_feature = "coprocessor")]
     F2: u32,
+    #[cfg(target_feature = "coprocessor")]
     F3: u32,
+    #[cfg(target_feature = "coprocessor")]
     F4: u32,
+    #[cfg(target_feature = "coprocessor")]
     F5: u32,
+    #[cfg(target_feature = "coprocessor")]
     F6: u32,
+    #[cfg(target_feature = "coprocessor")]
     F7: u32,
+    #[cfg(target_feature = "coprocessor")]
     F8: u32,
+    #[cfg(target_feature = "coprocessor")]
     F9: u32,
+    #[cfg(target_feature = "coprocessor")]
     F10: u32,
+    #[cfg(target_feature = "coprocessor")]
     F11: u32,
+    #[cfg(target_feature = "coprocessor")]
     F12: u32,
+    #[cfg(target_feature = "coprocessor")]
     F13: u32,
+    #[cfg(target_feature = "coprocessor")]
     F14: u32,
+    #[cfg(target_feature = "coprocessor")]
     F15: u32,
 
     reserved: [u32; 7],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![feature(asm)]
 #![feature(global_asm)]
 #![feature(naked_functions)]
-#![feature(stmt_expr_attributes)]
 
 pub use proc_macros::entry;
 pub use proc_macros::exception;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,22 +122,3 @@ macro_rules! cfg_asm {
         cfg_asm!(@inner, [], [$($opts)*], $($asms)*)
     };
 }
-
-#[macro_export]
-macro_rules! cfg_global_asm {
-    (@inner, [$($x:tt)*], [$($opts:tt)*], ) => {
-        global_asm!($($x)* $($opts)*)
-    };
-    (@inner, [$($x:tt)*], [$($opts:tt)*], #[cfg($meta:meta)] $asm:literal, $($rest:tt)*) => {
-        #[cfg($meta)]
-        cfg_asm!(@inner, [$($x)* $asm,], [$($opts)*], $($rest)*);
-        #[cfg(not($meta))]
-        cfg_asm!(@inner, [$($x)*], [$($opts)*], $($rest)*)
-    };
-    (@inner, [$($x:tt)*], [$($opts:tt)*], $asm:literal, $($rest:tt)*) => {
-        cfg_asm!(@inner, [$($x)* $asm,], [$($opts)*], $($rest)*)
-    };
-    ({$($asms:tt)*}, $($opts:tt)*) => {
-        cfg_asm!(@inner, [], [$($opts)*], $($asms)*)
-    };
-}


### PR DESCRIPTION
This is a WIP fleshing out of an idea we discussed a few meetings back, using the CPU features to manipulate what code is generated. As it stands, there is support for conditionally compiling `{save|restore}_context`, along with the `Context` structure. It should hopefully close #26.

It should hopefully be possible to remove the `lx106` specific code (for the esp8266), but this might be a bit more tricky; see below.

### Questions

- How to handle the vector table & exception handlers?
  - The number will vary depending on the silicon.
  - Is there ISA defined ordering of the vector table, i.e Will  `DebugExceptionVector` always come before `NMIExceptionVector` or is this how Espressif chose to layout the table in their chips?
- How to handle features (internal timers, interrupt levels, etc) that are not possible to find from the CPU features?

cc: @jessebraham @igrr 