### PR TITLE
Fix asm labels breakage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 #![feature(global_asm)]
 #![feature(naked_functions)]
 
+// required due to: https://github.com/rust-lang/rust/pull/87324
+#![allow(named_asm_labels)]
+
 pub use proc_macros::entry;
 pub use proc_macros::exception;
 pub use proc_macros::interrupt;


### PR DESCRIPTION
A new lint was added to try and avoid redefining local labels in asm.
However this breaks a valid case, where inline asm is used in `naked`
funtions. `naked` functions should never be inlined, hence redefinition
shouldn't either. This PR disables that lint.