### PR TITLE
Exception interception

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ Minimal runtime/startup for Xtensa LX processors. This crate currently supports 
 | `esp32s3` | ESP32-S3 (_LX7_)  |
 | `esp8266` | ESP8266 (_LX106_) |
 
+## I get linker errors when I build for debug
+
+Xtensa only provides a small code space for exceptions to fit inside, when building an unoptimized build the code size of a exception handler may exceed that size, causing a linker error. To fix this, you should always optimize this crate, even in debug builds. Adding the following to your projects `Cargo.toml` should do the trick.
+
+```toml
+[profile.dev.package.xtensa-lx-rt]
+opt-level = 'z'
+```
+
 ## License
 
 Licensed under either of

--- a/exception-esp32.x.jinja
+++ b/exception-esp32.x.jinja
@@ -2,6 +2,7 @@
 
 /* high level exception/interrupt routines, which can be override with Rust functions */
 PROVIDE(__exception = __default_exception);
+PROVIDE(__user_exception = __default_user_exception);
 PROVIDE(__double_exception = __default_double_exception);
 PROVIDE(__level_1_interrupt = __default_interrupt);
 PROVIDE(__level_2_interrupt = __default_interrupt);


### PR DESCRIPTION
Closes #38 

- Don't create __exception with xtensa_lx_rt::exception macro
- Use a fixed name for the user trap handler created with xtensa_lx_rt::exception
- Make the __default_exception call the fixed user trap handler
- Provide a default user handler (which will just panic)

I also added some remarks in the README about the exception handler size, and how debug builds can produce exception handlers that are too big.