### PR TITLE
v0.12.0 prep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtensa-lx-rt"
-version = "0.11.0"
+version = "0.12.0"
 description = "Low level access for Xtensa LX processors"
 categories = ["embedded", "hardware-support", "no-std"]
 keywords = ["xtensa", "lx", "register", "peripheral"]


### PR DESCRIPTION
I'd like to cut a new release, so I can publish the `xtensa-atomic-emulation-trap` crate. Is there anything anyone is working on that we should wait for?