### PR TITLE
CPU Interrupts

### DIFF
--- a/exception-esp32.x.jinja
+++ b/exception-esp32.x.jinja
@@ -12,6 +12,16 @@ PROVIDE(__level_5_interrupt = __default_interrupt);
 PROVIDE(__level_6_interrupt = __default_interrupt);
 PROVIDE(__level_7_interrupt = __default_interrupt);
 
+/* high level CPU interrupts */
+PROVIDE(Timer0 = __default_user_exception);
+PROVIDE(Timer1 = __default_user_exception);
+PROVIDE(Timer2 = __default_user_exception);
+PROVIDE(Timer3 = __default_user_exception);
+PROVIDE(Profiling = __default_user_exception);
+PROVIDE(NMI = __default_user_exception);
+PROVIDE(Software0 = __default_user_exception);
+PROVIDE(Software1 = __default_user_exception);
+
 /* low level exception/interrupt, which must be overridden using naked functions */
 PROVIDE(__naked_user_exception = __default_naked_exception);
 PROVIDE(__naked_kernel_exception = __default_naked_exception);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,29 @@ unsafe fn reset_internal_timers() {
     }
 }
 
+// CPU Interrupts
+extern "C" {
+    #[cfg(XCHAL_HAVE_TIMER0)]
+    pub fn Timer0(level: u32);
+    #[cfg(XCHAL_HAVE_TIMER1)]
+    pub fn Timer1(level: u32);
+    #[cfg(XCHAL_HAVE_TIMER2)]
+    pub fn Timer2(level: u32);
+    #[cfg(XCHAL_HAVE_TIMER3)]
+    pub fn Timer3(level: u32);
+
+    #[cfg(XCHAL_HAVE_PROFILING)]
+    pub fn Profiling(level: u32);
+
+    #[cfg(XCHAL_HAVE_SOFTWARE0)]
+    pub fn Software0(level: u32);
+    #[cfg(XCHAL_HAVE_SOFTWARE1)]
+    pub fn Software1(level: u32);
+
+    #[cfg(XCHAL_HAVE_NMI)]
+    pub fn NMI(level: u32);
+}
+
 #[doc(hidden)]
 #[inline]
 unsafe fn set_vecbase(base: *const u32) {


### PR DESCRIPTION
Adds handlers for CPU sources based on overlay config, the implementation that calls these has to be done in the hal as the interrupt controller is chip-specific.

Closes https://github.com/esp-rs/xtensa-lx-rt/issues/29.


Another option would be to do what we did in esp32-hal and patch the SVD's to add CPU interrupt sources as peripheral sources.