### PR TITLE
allow interrupt level preemption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtensa-lx-rt"
-version = "0.12.0"
+version = "0.13.0"
 description = "Low level access for Xtensa LX processors"
 categories = ["embedded", "hardware-support", "no-std"]
 keywords = ["xtensa", "lx", "register", "peripheral"]

--- a/src/exception/assembly_esp32.rs
+++ b/src/exception/assembly_esp32.rs
@@ -493,6 +493,10 @@ unsafe extern "C" fn __default_naked_exception() {
         j       .RestoreContext
 
         .Level1Interrupt:
+        movi    a0, (1 | PS_WOE)          // set PS.INTLEVEL accordingly
+        wsr     a0, PS
+        rsync
+
         movi    a6, 1                     // put interrupt level in a6 = a2 in callee
         mov     a7, sp                    // put address of save frame in a7=a3 in callee
         call4   __level_1_interrupt       // call handler <= actual call!
@@ -569,7 +573,7 @@ global_asm!(
     .macro HANDLE_INTERRUPT_LEVEL level
     SAVE_CONTEXT \level
 
-    movi    a0, (PS_INTLEVEL_EXCM | PS_WOE)
+    movi    a0, (\level | PS_WOE)
     wsr     a0, PS
     rsync
 


### PR DESCRIPTION
Closes #46.

Bumps the version to 0.13.0 too.