### PR TITLE
Define CPU interrupt functions receiving `&mut Context`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -127,7 +127,10 @@ fn inject_cfgs(isa_config: &HashMap<String, Value>) {
 
 fn inject_cpu_cfgs(isa_config: &HashMap<String, Value>) {
     for (key, value) in isa_config {
-        if key.starts_with("XCHAL_TIMER") || key.starts_with("XCHAL_PROFILING") || key.starts_with("XCHAL_NMI") {
+        if key.starts_with("XCHAL_TIMER")
+            || key.starts_with("XCHAL_PROFILING")
+            || key.starts_with("XCHAL_NMI")
+        {
             if let Some(_) = value.as_integer() {
                 let mut s = String::from(key.trim_end_matches("_INTERRUPT"));
                 let first = s.chars().position(|c| c == '_').unwrap() + 1;
@@ -136,7 +139,11 @@ fn inject_cpu_cfgs(isa_config: &HashMap<String, Value>) {
             }
         }
     }
-    if let Some(value) = isa_config.get("XCHAL_INTTYPE_MASK_SOFTWARE").map(|v| v.as_integer()).flatten() {
+    if let Some(value) = isa_config
+        .get("XCHAL_INTTYPE_MASK_SOFTWARE")
+        .map(|v| v.as_integer())
+        .flatten()
+    {
         for i in 0..value.count_ones() {
             println!("cargo:rustc-cfg=XCHAL_HAVE_SOFTWARE{}", i);
         }

--- a/interrupt_level_masks.rs.jinja
+++ b/interrupt_level_masks.rs.jinja
@@ -11,13 +11,13 @@ pub enum CpuInterruptLevel {
 impl CpuInterruptLevel {
     pub fn mask(&self) -> u32 {
         match &self {
-            CpuInterruptLevel::Level1 => ({{ XCHAL_INTLEVEL1_MASK }}u32),
-            CpuInterruptLevel::Level2 => ({{ XCHAL_INTLEVEL2_MASK }}u32),
-            CpuInterruptLevel::Level3 => ({{ XCHAL_INTLEVEL3_MASK }}u32),
-            CpuInterruptLevel::Level4 => ({{ XCHAL_INTLEVEL4_MASK }}u32),
-            CpuInterruptLevel::Level5 => ({{ XCHAL_INTLEVEL5_MASK }}u32),
-            CpuInterruptLevel::Level6 => ({{ XCHAL_INTLEVEL6_MASK }}u32),
-            CpuInterruptLevel::Level7 => ({{ XCHAL_INTLEVEL7_MASK }}u32),
+            CpuInterruptLevel::Level1 => {{ XCHAL_INTLEVEL1_MASK }}u32,
+            CpuInterruptLevel::Level2 => {{ XCHAL_INTLEVEL2_MASK }}u32,
+            CpuInterruptLevel::Level3 => {{ XCHAL_INTLEVEL3_MASK }}u32,
+            CpuInterruptLevel::Level4 => {{ XCHAL_INTLEVEL4_MASK }}u32,
+            CpuInterruptLevel::Level5 => {{ XCHAL_INTLEVEL5_MASK }}u32,
+            CpuInterruptLevel::Level6 => {{ XCHAL_INTLEVEL6_MASK }}u32,
+            CpuInterruptLevel::Level7 => {{ XCHAL_INTLEVEL7_MASK }}u32,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,24 +110,24 @@ unsafe fn reset_internal_timers() {
 // CPU Interrupts
 extern "C" {
     #[cfg(XCHAL_HAVE_TIMER0)]
-    pub fn Timer0(level: u32);
+    pub fn Timer0(level: u32, save_frame: &mut crate::exception::Context);
     #[cfg(XCHAL_HAVE_TIMER1)]
-    pub fn Timer1(level: u32);
+    pub fn Timer1(level: u32, save_frame: &mut crate::exception::Context);
     #[cfg(XCHAL_HAVE_TIMER2)]
-    pub fn Timer2(level: u32);
+    pub fn Timer2(level: u32, save_frame: &mut crate::exception::Context);
     #[cfg(XCHAL_HAVE_TIMER3)]
-    pub fn Timer3(level: u32);
+    pub fn Timer3(level: u32, save_frame: &mut crate::exception::Context);
 
     #[cfg(XCHAL_HAVE_PROFILING)]
-    pub fn Profiling(level: u32);
+    pub fn Profiling(level: u32, save_frame: &mut crate::exception::Context);
 
     #[cfg(XCHAL_HAVE_SOFTWARE0)]
-    pub fn Software0(level: u32);
+    pub fn Software0(level: u32, save_frame: &mut crate::exception::Context);
     #[cfg(XCHAL_HAVE_SOFTWARE1)]
-    pub fn Software1(level: u32);
+    pub fn Software1(level: u32, save_frame: &mut crate::exception::Context);
 
     #[cfg(XCHAL_HAVE_NMI)]
-    pub fn NMI(level: u32);
+    pub fn NMI(level: u32, save_frame: &mut crate::exception::Context);
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
I'm currently implementing "yield" from a task in `esp-wifi` - for that it's needed to receive a mutable reference to the trap-frame for software interrupts (like we already have it for peripheral interrupts)

This is in preparation for an upcoming PR in `esp-hal`

We also need this on crates-io - I guess releasing this as 0.14.0 should be fine since it's not semver compatible and shouldn't get picked up automatically

