### PR TITLE
Avoid expanded-macros triggering clippy::pedantic for dependants

### DIFF
--- a/procmacros/src/lib.rs
+++ b/procmacros/src/lib.rs
@@ -112,6 +112,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
             )
         }
 
+        #[allow(clippy::inline_always)]
         #[inline(always)]
         #f
     )
@@ -354,6 +355,7 @@ pub fn interrupt(args: TokenStream, input: TokenStream) -> TokenStream {
                 )
             }
 
+            #[allow(clippy::inline_always)]
             #[inline(always)]
             #f
         )
@@ -373,6 +375,7 @@ pub fn interrupt(args: TokenStream, input: TokenStream) -> TokenStream {
                 )
             }
 
+            #[allow(clippy::inline_always)]
             #[inline(always)]
             #f
         )


### PR DESCRIPTION
When running `cargo clippy -- -W clippy::pedantic` on an esp32s3 project generated from the template, I get:

```
   Compiling xtensa-lx-rt-proc-macros v0.2.0 (/path/to/xtensa-lx-rt/procmacros)
    Checking xtensa-lx-rt v0.15.0
    Checking esp-hal-common v0.9.0
    Checking esp32s3-hal v0.9.0
    Checking my_proj v0.1.0 (/path/to/my_proj)
warning: you have declared `#[inline(always)]` on `__xtensa_lx_rt_main`. This is usually a bad idea
 --> src/main.rs:8:1
  |
8 | #[entry]
  | ^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#inline_always
  = note: `-W clippy::inline-always` implied by `-W clippy::pedantic`
  = note: this warning originates in the attribute macro `entry` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `my_proj` (bin "my_proj") generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 2.68s
```
    
Relevant expanded code:
    
```rust

#[doc(hidden)]
#[export_name = "main"]
pub unsafe extern "C" fn __xtensa_lx_rt_main_trampoline() {
    __xtensa_lx_rt_main()
}
#[inline(always)]
fn __xtensa_lx_rt_main() -> ! {
    let peripherals = Peripherals::take();
    let mut system = peripherals.SYSTEM.split();

```

this PR adds `#[allow(inline::always)]` above the actual inline annotation on my project, and _should_ do the same for other inline-annotated functions.

Possible follow-up to this would be to add into CI a means to ensure macro-expansions won't trigger clippy::pedantic in dependants when expanded.