### PR TITLE
Add a `__post_init` hook, general updating and cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
 name = "xtensa-lx-rt"
 version = "0.15.0"
-description = "Low level access for Xtensa LX processors"
-categories = ["embedded", "hardware-support", "no-std"]
-keywords = ["xtensa", "lx", "register", "peripheral"]
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/esp-rs/xtensa-lx-rt"
 authors = [
     "Scott Mabin <scott@mabez.dev>", 
     "Arjan Mels <arjan@mels.email>",
     "Robin Appelman <robin@icewind.nl>",
 ]
-edition = "2018"
+edition = "2021"
+rust-version = "1.65"
+description = "Low level access for Xtensa LX processors"
+readme = "README.md"
+repository = "https://github.com/esp-rs/xtensa-lx-rt"
+license = "MIT OR Apache-2.0"
+keywords = ["xtensa", "lx", "register", "peripheral"]
+categories = ["embedded", "hardware-support", "no-std"]
 
 [package.metadata.docs.rs]
 features = ["esp32"]
@@ -24,7 +25,7 @@ xtensa-lx-rt-proc-macros = { path = "procmacros", version = "=0.2.0" }
 
 [build-dependencies]
 core-isa-parser = { path = "core-isa-parser", version = "=0.2.0" }
-minijinja = "0.15.0"
+minijinja = "1.0.7"
 
 [features]
 esp32   = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtensa-lx-rt"
-version = "0.15.0"
+version = "0.16.0"
 authors = [
     "Scott Mabin <scott@mabez.dev>", 
     "Arjan Mels <arjan@mels.email>",
@@ -21,7 +21,7 @@ features = ["esp32"]
 [dependencies]
 bare-metal = "1.0.0"
 r0 = "1.0.0"
-xtensa-lx-rt-proc-macros = { path = "procmacros", version = "=0.2.0" }
+xtensa-lx-rt-proc-macros = { path = "procmacros", version = "=0.2.1" }
 
 [build-dependencies]
 core-isa-parser = { path = "core-isa-parser", version = "=0.2.0" }

--- a/procmacros/Cargo.toml
+++ b/procmacros/Cargo.toml
@@ -1,23 +1,25 @@
-  
 [package]
-authors = ["Jorge Aparicio <jorge@japaric.io>","Arjan Mels <arjan@mels.email>", "Scott Mabin <scott@mabez.dev>"]
-categories = ["embedded", "no-std"]
+name = "xtensa-lx-rt-proc-macros"
+authors = [
+    "Jorge Aparicio <jorge@japaric.io>",
+    "Arjan Mels <arjan@mels.email>",
+    "Scott Mabin <scott@mabez.dev>",
+]
+version = "0.2.0"
+edition = "2021"
+rust-version = "1.65"
 description = "Attributes re-exported in `xtensa-lx-rt`"
 documentation = "https://docs.rs/xtensa-lx-rt"
-keywords = ["esp32", "xtensa-lx-rt", "runtime", "startup"]
-license = "MIT OR Apache-2.0"
-name = "xtensa-lx-rt-proc-macros"
 repository = "https://github.com/esp-rs/xtensa-lx-rt"
-version = "0.2.0"
-edition = "2018"
+license = "MIT OR Apache-2.0"
+keywords = ["esp32", "xtensa-lx-rt", "runtime", "startup"]
+categories = ["embedded", "no-std"]
 
 [lib]
 proc-macro = true
 
 [dependencies]
-quote = "1.0"
+darling = "0.20"
 proc-macro2 = "1.0"
-
-[dependencies.syn]
-features = ["extra-traits", "full"]
-version = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["extra-traits", "full"] }

--- a/procmacros/Cargo.toml
+++ b/procmacros/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Arjan Mels <arjan@mels.email>",
     "Scott Mabin <scott@mabez.dev>",
 ]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.65"
 description = "Attributes re-exported in `xtensa-lx-rt`"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "esp"

--- a/xtensa.in.x
+++ b/xtensa.in.x
@@ -8,6 +8,7 @@ INCLUDE memory.x
 PROVIDE(__pre_init = DefaultPreInit);
 PROVIDE(__zero_bss = default_mem_hook);
 PROVIDE(__init_data = default_mem_hook);
+PROVIDE(__post_init = default_post_init);
 
 INCLUDE exception.x
 


### PR DESCRIPTION
- Adds a `__post_init` hook, like we have in `esp-riscv-rt`
- Updates dependencies to their latest versions
    - Updated `syn` from `1.x` to `2.x` in the proc-macro crate
- Bumped version numbers of `xtensa-lx-rt-proc-macros` and `xtensa-lx-rt` packages in preparation for new release
- Added a `rust-toolchain.toml` file

Sorry for the other noise, just trying to get the Cargo manifests consistent with the others. Additionally I bumped the MSRV to `1.65` since that's what we're using for the PACs/HALs anyway.